### PR TITLE
Fix vote aggregation logic

### DIFF
--- a/src/components/VoteModal.tsx
+++ b/src/components/VoteModal.tsx
@@ -2,9 +2,8 @@
 'use client'
 
 import { Dialog } from '@headlessui/react'
-import { useState, Fragment } from 'react'
+import { useState } from 'react'
 import { submitVoteToFirestore } from '@/lib/submitVoteToFirestore'
-import { on } from 'events'
 
 type Candidate = {
   id: string

--- a/src/hooks/useVoteCounts.ts
+++ b/src/hooks/useVoteCounts.ts
@@ -1,26 +1,44 @@
 import { useEffect, useState } from 'react'
 import { db } from '@/firebase/firebase'
-import { collection, onSnapshot, query, where } from 'firebase/firestore'
+import { collection, onSnapshot, doc } from 'firebase/firestore'
 
 export function useVoteCounts(region?: string): Record<string, number> {
   const [counts, setCounts] = useState<Record<string, number>>({})
 
   useEffect(() => {
-    const base = collection(db, 'votes')
-    const q = region ? query(base, where('region', '==', region)) : base
+    if (region) {
+      const ref = doc(db, 'votes', region)
+      const unsub = onSnapshot(ref, (snap) => {
+        const data = snap.data() as Record<string, { total: number }> | undefined
+        const totals: Record<string, number> = {}
 
-    const unsubscribe = onSnapshot(q, (snapshot) => {
-      const newCounts: Record<string, number> = {}
+        if (data) {
+          for (const [candidate, info] of Object.entries(data)) {
+            totals[candidate] = info.total || 0
+          }
+        }
 
-      snapshot.forEach((doc) => {
-        const name = doc.data().candidate
-        newCounts[name] = (newCounts[name] || 0) + 1
+        setCounts(totals)
       })
 
-      setCounts(newCounts)
-    })
+      return () => unsub()
+    } else {
+      const colRef = collection(db, 'votes')
+      const unsub = onSnapshot(colRef, (snapshot) => {
+        const totals: Record<string, number> = {}
 
-    return () => unsubscribe()
+        snapshot.forEach((doc) => {
+          const data = doc.data() as Record<string, { total: number }>
+          for (const [candidate, info] of Object.entries(data)) {
+            totals[candidate] = (totals[candidate] || 0) + (info.total || 0)
+          }
+        })
+
+        setCounts(totals)
+      })
+
+      return () => unsub()
+    }
   }, [region])
 
   return counts


### PR DESCRIPTION
## Summary
- fix vote counting hook to read data from Firestore documents correctly
- clean up unused imports in VoteModal

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faf3b50f08331abcb3cab564059d7